### PR TITLE
Space out normal paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [x] Add method to toggle task list:
   - [x] For normal mode
   - [x] For visual mode
-- [ ] Make it so that when list elements are fully outdented (they are no
+- [x] Make it so that when list elements are fully outdented (they are no
       longer list elements), empty lines are added in the spaces between any
       adjacent list elements and normal paragraph lines
 - [ ] Add method to toggle between lists and standard paragraphs

--- a/lua/smark/buffer.lua
+++ b/lua/smark/buffer.lua
@@ -207,11 +207,26 @@ end
 ---@param li_block_bounds TextBlockBounds
 ---@param li_cursor_coords? LiCursorCoords
 function M.draw_list_items(li_block, read_time_lines, li_block_bounds, li_cursor_coords)
+	local previous_li_fully_outdented = false
 	local write_time_lines = {}
 	for _, li in ipairs(li_block) do
 		local li_as_strings = list_item.to_lines(li)
+
+		if
+			(previous_li_fully_outdented and #li.indent_rules > 0)
+			or (not previous_li_fully_outdented and #li.indent_rules == 0)
+		then
+			table.insert(write_time_lines, "")
+		end
+
 		for _, s in ipairs(li_as_strings) do
 			table.insert(write_time_lines, s)
+		end
+
+		if #li.indent_rules == 0 then
+			previous_li_fully_outdented = true
+		else
+			previous_li_fully_outdented = false
 		end
 	end
 

--- a/lua/smark/buffer.lua
+++ b/lua/smark/buffer.lua
@@ -207,6 +207,8 @@ end
 ---@param li_block_bounds TextBlockBounds
 ---@param li_cursor_coords? LiCursorCoords
 function M.draw_list_items(li_block, read_time_lines, li_block_bounds, li_cursor_coords)
+	---@type TextBlockBounds|nil
+	local change_guarantee_block = nil
 	local previous_li_fully_outdented = false
 	local write_time_lines = {}
 	for _, li in ipairs(li_block) do
@@ -217,6 +219,11 @@ function M.draw_list_items(li_block, read_time_lines, li_block_bounds, li_cursor
 			or (not previous_li_fully_outdented and #li.indent_rules == 0)
 		then
 			table.insert(write_time_lines, "")
+			if change_guarantee_block == nil then
+				change_guarantee_block = { upper = #write_time_lines, lower = #write_time_lines }
+			else
+				change_guarantee_block.lower = #write_time_lines
+			end
 		end
 
 		for _, s in ipairs(li_as_strings) do
@@ -242,19 +249,30 @@ function M.draw_list_items(li_block, read_time_lines, li_block_bounds, li_cursor
 
 	assert(li_cursor_coords ~= nil, "li_cursor_coords must be supplied if active changes have been made to the text")
 
-	local relative_row = cursor.get_row_relative_to_li_block_bounds(li_cursor_coords, li_block)
+	local new_lines
+	if change_guarantee_block == nil then
+		new_lines = 1
+		local cursor_line_index = cursor.get_row_relative_to_li_block_bounds(li_cursor_coords, li_block)
+		change_guarantee_block = { upper = cursor_line_index, lower = cursor_line_index }
+	else
+		new_lines = 2
+	end
 
 	for i, s in ipairs(write_time_lines) do
 		local absolute_ln = li_block_bounds.upper + i - 1
 
-		if i < relative_row then
+		if i < change_guarantee_block.upper then
 			if read_time_lines[i] ~= s then
 				vim.api.nvim_buf_set_lines(0, absolute_ln - 1, absolute_ln, true, { s })
 			end
-		elseif i == relative_row then
+		elseif i == change_guarantee_block.upper then
+			vim.api.nvim_buf_set_lines(0, absolute_ln - 1, absolute_ln - 1, true, { s })
+		elseif i > change_guarantee_block.upper and i < change_guarantee_block.lower then
+			vim.api.nvim_buf_set_lines(0, absolute_ln - 1, absolute_ln, true, { s })
+		elseif i == change_guarantee_block.lower then
 			vim.api.nvim_buf_set_lines(0, absolute_ln - 1, absolute_ln - 1, true, { s })
 		else
-			if read_time_lines[i - 1] ~= s then
+			if read_time_lines[i - new_lines] ~= s then
 				vim.api.nvim_buf_set_lines(0, absolute_ln - 1, absolute_ln, true, { s })
 			end
 		end

--- a/lua/smark/cursor.lua
+++ b/lua/smark/cursor.lua
@@ -69,13 +69,28 @@ end
 function M.get_row_relative_to_li_block_bounds(li_cursor_coords, li_block)
 	local offset = 0
 
+	local previous_li_fully_outdented = false
 	for i = 1, li_cursor_coords.list_index do
 		local li = li_block[i]
 
+		local separator_row = 0
+		if
+			(previous_li_fully_outdented and #li.indent_rules > 0)
+			or (not previous_li_fully_outdented and #li.indent_rules == 0)
+		then
+			separator_row = 1
+		end
+
 		if i < li_cursor_coords.list_index then
-			offset = offset + #li.content
+			offset = offset + separator_row + #li.content
 		else
-			offset = offset + li_cursor_coords.content_lnum
+			offset = offset + separator_row + li_cursor_coords.content_lnum
+		end
+
+		if #li.indent_rules == 0 then
+			previous_li_fully_outdented = true
+		else
+			previous_li_fully_outdented = false
 		end
 	end
 

--- a/lua/smark/operator.lua
+++ b/lua/smark/operator.lua
@@ -46,7 +46,7 @@ function M.visual_indent()
 end
 
 function M.visual_unindent()
-	local li_block_bounds, li_block, read_time_lines = buffer.get_list_block_around_cursor()
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords = buffer.get_list_block_around_cursor()
 	assert(li_block_bounds ~= nil, "op called outside of list block")
 
 	local start_row = vim.fn.getpos("'<")[2]
@@ -57,7 +57,7 @@ function M.visual_unindent()
 	for _ = 1, vim.v.count1 do
 		list_manipulation.apply_unindent(li_block, start_index, end_index)
 	end
-	buffer.draw_list_items(li_block, read_time_lines, li_block_bounds)
+	buffer.draw_list_items(li_block, read_time_lines, li_block_bounds, li_cursor_coords)
 end
 
 function M.visual_toggle_ordered()

--- a/tests/test_indentation.lua
+++ b/tests/test_indentation.lua
@@ -238,17 +238,26 @@ T["normal"]["outdentation at root destroys list element"] = function()
 	child.api.nvim_buf_set_lines(0, 0, 0, true, {
 		"- Foo",
 		"- Bar",
+		"- Baz",
 	})
-	child.api.nvim_win_set_cursor(0, { 2, 0 })
+	child.api.nvim_win_set_cursor(0, { 2, 2 })
 	child.type_keys("<lt><lt>")
 
-	local result_buffer = child.api.nvim_buf_get_lines(0, 0, 2, true)
+	local result_buffer = child.api.nvim_buf_get_lines(0, 0, 5, true)
 	local expected_buffer = {
 		"- Foo",
+		"",
 		"Bar",
+		"",
+		"- Baz",
 	}
 
 	eq(result_buffer, expected_buffer)
+
+	local result_cursor_coords = child.api.nvim_win_get_cursor(0)
+	local expected_cursor_coords = { 3, 2 }
+
+	eq(result_cursor_coords, expected_cursor_coords)
 end
 
 T["normal"]["outdentation understands multi-line lists"] = function()
@@ -451,12 +460,14 @@ T["visual"]["over-outdentation should destroy list elements"] = function()
 	child.api.nvim_win_set_cursor(0, { 4, 0 })
 	child.type_keys("V2k10<lt>")
 
-	local result_buffer = child.api.nvim_buf_get_lines(0, 0, 5, true)
+	local result_buffer = child.api.nvim_buf_get_lines(0, 0, 7, true)
 	local expected_buffer = {
 		"1. Foo",
+		"",
 		"Bar",
 		"Baz",
 		"Noice",
+		"",
 		"1. Sheesh",
 	}
 

--- a/tests/test_internals.lua
+++ b/tests/test_internals.lua
@@ -7,14 +7,6 @@ local T = new_set({
 		pre_case = function()
 			child.restart({ "-u", "scripts/minimal_init.lua" })
 			child.lua("require('smark').setup()")
-			child.lua([[
-				_G._set_lines_calls = {}
-				local orig = vim.api.nvim_buf_set_lines
-				vim.api.nvim_buf_set_lines = function(buf, start, end_, strict, lines)
-					table.insert(_G._set_lines_calls, {buf=buf, start=start, end_=end_, strict=strict, lines=vim.deepcopy(lines)})
-					return orig(buf, start, end_, strict, lines)
-				end
-			]])
 			child.bo.filetype = "markdown"
 		end,
 		post_once = child.stop,
@@ -24,6 +16,15 @@ local T = new_set({
 T["insert_CR"] = new_set()
 
 T["insert_CR"]["rewrite_lines"] = function()
+	child.lua([[
+		_G._set_lines_calls = {}
+		local orig = vim.api.nvim_buf_set_lines
+		vim.api.nvim_buf_set_lines = function(buf, start, end_, strict, lines)
+			table.insert(_G._set_lines_calls, {buf=buf, start=start, end_=end_, strict=strict, lines=vim.deepcopy(lines)})
+			return orig(buf, start, end_, strict, lines)
+		end
+	]])
+
 	local original_lines = {
 		"- This piece of legislation:",
 		"  - Provides single clear test for assessing capacity",
@@ -65,6 +66,150 @@ T["insert_CR"]["rewrite_lines"] = function()
 		end_ = 15,
 		strict = true,
 		lines = { "  - " },
+	})
+end
+
+T["insert_CR"]["rewrite_lines and check buffer contents"] = function()
+	child.lua([[
+		_G._set_lines_calls = {}
+		local orig = vim.api.nvim_buf_set_lines
+		vim.api.nvim_buf_set_lines = function(buf, start, end_, strict, lines)
+			table.insert(_G._set_lines_calls, {buf=buf, start=start, end_=end_, strict=strict, lines=vim.deepcopy(lines)})
+			return orig(buf, start, end_, strict, lines)
+		end
+	]])
+
+	local original_lines = {
+		"- If patient < 5 years, clinical judgement",
+		"- Otherwise, try below investigations in order and diagnose if any abnormal:",
+		"  1. [[FeNO_test]] (or [[eosinophil]] count for adults):",
+		"     - If either are above reference range, diagnose asthma",
+		"  2. [[spirometry]]:",
+		"     - If obstructive picture with [[bronchodilator]] reversibility, diagnose",
+		"       asthma",
+		"  3. Twice daily [[PEFR]] diary for 2 weeks:",
+		"     - If [[PEFR]] variability amplitude percentage mean > 20%, diagnose asthma",
+		"  4. Bronchial challenge testing:",
+		"     - In children, try [[eosinophil]] count and [[IgE]] levels first",
+		"  5. For children if still inconclusive, refer to paediatric respiratory",
+		"     physician",
+	}
+	child.api.nvim_buf_set_lines(0, 0, 0, true, original_lines)
+	child.api.nvim_win_set_cursor(0, { 4, 0 })
+	child.type_keys("A<CR>Test<CR>Foobarbaz")
+
+	local expected_buffer = {
+		"- If patient < 5 years, clinical judgement",
+		"- Otherwise, try below investigations in order and diagnose if any abnormal:",
+		"  1. [[FeNO_test]] (or [[eosinophil]] count for adults):",
+		"     - If either are above reference range, diagnose asthma",
+		"     - Test",
+		"     - Foobarbaz",
+		"  2. [[spirometry]]:",
+		"     - If obstructive picture with [[bronchodilator]] reversibility, diagnose",
+		"       asthma",
+		"  3. Twice daily [[PEFR]] diary for 2 weeks:",
+		"     - If [[PEFR]] variability amplitude percentage mean > 20%, diagnose asthma",
+		"  4. Bronchial challenge testing:",
+		"     - In children, try [[eosinophil]] count and [[IgE]] levels first",
+		"  5. For children if still inconclusive, refer to paediatric respiratory",
+		"     physician",
+	}
+	local result_buffer = child.api.nvim_buf_get_lines(0, 0, 15, true)
+
+	eq(result_buffer, expected_buffer)
+
+	local calls = child.lua_get("_G._set_lines_calls")
+
+	eq(#calls, 2)
+	eq(calls[1], {
+		buf = 0,
+		start = 4,
+		end_ = 4,
+		strict = true,
+		lines = { "     - " },
+	})
+	eq(calls[2], {
+		buf = 0,
+		start = 5,
+		end_ = 5,
+		strict = true,
+		lines = { "     - " },
+	})
+end
+
+T["insert_CR"]["rewrite_lines with full outdentation"] = function()
+	child.lua([[
+		_G._set_lines_calls = {}
+		local orig = vim.api.nvim_buf_set_lines
+		vim.api.nvim_buf_set_lines = function(buf, start, end_, strict, lines)
+			table.insert(_G._set_lines_calls, {buf=buf, start=start, end_=end_, strict=strict, lines=vim.deepcopy(lines)})
+			return orig(buf, start, end_, strict, lines)
+		end
+	]])
+
+	local original_lines = {
+		"- This piece of legislation:",
+		"  - Provides single clear test for assessing capacity",
+		"    ([[2-stage_test_for_capacity]])",
+		"  - Checklist for making best interest decisions",
+		"  - Allows decision-maker to be assigned to person if they cannot make their",
+		"    own decisions",
+		"  - Defines deprivation of liberty",
+		"  - Provides safeguards ([[Deprivation_of_Liberty_Safeguards]])",
+		"- Types of decisions covered:",
+		"  - Healthcare",
+		"  - Place of residence",
+		"  - Financial",
+		"- Statutory framework to protect vulnerable people who may not be able to make",
+		"  decisions for themselves",
+		"- Historical context:",
+		"  - The [[MHA]] was created to put safeguards into place for vulnerable people",
+		"    with mental health disorders",
+		"  - However [[MHA]] does not apply when patients do not have a mental health",
+		"    disorder",
+		"  - The MCA was created to cover this hole, and comes with legal framework to",
+		"    safeguard people in general",
+		"  - However as the [[MHA]] is a more powerful legal framework, it should be",
+		"    used in preference",
+		"- When determination of best interests relates to life-sustaining treatment,",
+		"  decision maker must not be motivated by a desire to bring about the patient's",
+		"  death",
+	}
+	child.api.nvim_buf_set_lines(0, 0, 0, true, original_lines)
+	child.api.nvim_win_set_cursor(0, { 13, 0 })
+	child.type_keys("<lt><lt>")
+
+	local calls = child.lua_get("_G._set_lines_calls")
+
+	eq(#calls, 4)
+	eq(calls[1], {
+		buf = 0,
+		start = 12,
+		end_ = 12,
+		strict = true,
+		lines = { "" },
+	})
+	eq(calls[2], {
+		buf = 0,
+		start = 13,
+		end_ = 14,
+		strict = true,
+		lines = { "Statutory framework to protect vulnerable people who may not be able to make" },
+	})
+	eq(calls[3], {
+		buf = 0,
+		start = 14,
+		end_ = 15,
+		strict = true,
+		lines = { "decisions for themselves" },
+	})
+	eq(calls[4], {
+		buf = 0,
+		start = 15,
+		end_ = 15,
+		strict = true,
+		lines = { "" },
 	})
 end
 


### PR DESCRIPTION
Now, if you fully outdent a list item so that now it turns into a normal paragraph, smark inserts empty lines between the newly created paragraph and any adjacent list elements so that parsers don't confuse the paragraph as part of the contents of the list items.