### PR TITLE
Expose new multiline list behaviour as configurable option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - [ ] Smark should intelligently infer whether a new list item should be a task
       list item or not
-- [ ] Prose text directly below a list item should only be considered part of
+- [x] Prose text directly below a list item should only be considered part of
       the list item contents if the prose text is indented at least with one
       space
 

--- a/README.md
+++ b/README.md
@@ -38,21 +38,27 @@ return {
   {
     "yutanagano/smark.nvim",
     ft = { "markdown", "text" },
-    -- You can omit the opts table below and simply set config = true if you
-    -- are happy with the default settings
+    --Below are the default settings for the available options. You can omit
+    --the opts table below and simply set config = true if you are happy with
+    --the default settings.
     opts = {
-      --Default keymapping settings for list action commands.
+      --Keymapping settings for list action commands.
       --Set to false to disable.
       mappings = {
-        --Format the current list block to be clean / correct
+        --Format the current list block to be clean / correct.
         format_list = "<leader>lf",
-        --Switch between ordered / unordered list types
+        --Switch between ordered / unordered list types.
         toggle_ordered = "<leader>lo",
-        --Toggle the completion status of a task list item
+        --Toggle the completion status of a task list item.
         toggle_completion = "<leader>lx",
-        --Toggle between plain and task list items
+        --Toggle between plain and task list items.
         toggle_task = "<leader>lt",
       },
+
+      --Following the starting line of a list item, only contiguous lines that
+      --start with at least one whitespace character can be considered as part of
+      --a multi-line list item.
+      multiline_requires_whitespace = false,
     },
   }
 }

--- a/lua/smark/buffer.lua
+++ b/lua/smark/buffer.lua
@@ -6,7 +6,11 @@ if table.unpack == nil then -- compatibility with older Lua
 	table.unpack = unpack
 end
 
-local M = {}
+local M = {
+	--Setting controlling multi-line list element detection behaviour, see
+	--init.lua.
+	multiline_requires_whitespace = false,
+}
 
 ---Check if the cursor is currently inside of a list block. If it is, then
 ---return the items below concerning the current list block.
@@ -46,7 +50,7 @@ function M.get_list_block_around_cursor()
 		li, li_bounds, li_read_time_lines = M.scan_text_around_line(li_block_bounds.upper - 1)
 
 		if li == nil then
-			if string.len(li_read_time_lines[#li_read_time_lines]) > 0 then
+			if li_read_time_lines[#li_read_time_lines] ~= "" then
 				to_put_separator_at_start = true
 			end
 			break
@@ -64,7 +68,7 @@ function M.get_list_block_around_cursor()
 		li, li_bounds, li_read_time_lines = M.scan_text_around_line(li_block_bounds.lower + 1)
 
 		if li == nil then
-			if string.len(li_read_time_lines[1]) > 0 then
+			if li_read_time_lines[1] ~= "" then
 				to_put_separator_at_end = true
 			end
 			break
@@ -115,7 +119,7 @@ function M.scan_text_around_line(line_num)
 
 	local bounds = { upper = line_num, lower = line_num }
 
-	if li_shell == nil and cursor_line_preamble_len == 0 then
+	if li_shell == nil and M.line_confirmed_not_in_li(content_line, cursor_line_preamble_len) then
 		return nil, bounds, { raw_line }, cursor_line_preamble_len
 	end
 
@@ -129,7 +133,7 @@ function M.scan_text_around_line(line_num)
 			raw_line = vim.api.nvim_buf_get_lines(0, current_lnum - 1, current_lnum, true)[1]
 			li_shell, content_line, current_line_preamble_len = M.pattern_match_line(raw_line)
 
-			if current_line_preamble_len == 0 then
+			if M.line_confirmed_not_in_li(content_line, current_line_preamble_len) then
 				bounds.upper = current_lnum + 1
 				break
 			end
@@ -149,7 +153,7 @@ function M.scan_text_around_line(line_num)
 		raw_line = vim.api.nvim_buf_get_lines(0, current_lnum - 1, current_lnum, true)[1]
 		li_shell, content_line, current_line_preamble_len = M.pattern_match_line(raw_line)
 
-		if current_line_preamble_len == 0 or li_shell ~= nil then
+		if M.line_confirmed_not_in_li(content_line, current_line_preamble_len) or li_shell ~= nil then
 			bounds.lower = current_lnum - 1
 			break
 		end
@@ -233,6 +237,20 @@ function M.pattern_match_task_root(text)
 	local is_completed = completion == "x" or completion == "X"
 
 	return true, is_completed, content_line, string.len(preamble)
+end
+
+---Note that the behaviour of this function depends on the module setting
+---multiline_requires_whitespace.
+---
+---@param content_line string
+---@param preamble_len integer
+---@return boolean in_li True if line is definitely not part of list item.
+function M.line_confirmed_not_in_li(content_line, preamble_len)
+	if M.multiline_requires_whitespace then
+		return preamble_len == 0
+	end
+
+	return content_line == ""
 end
 
 ---Draw out string representations of list items in li_array between the lines

--- a/lua/smark/buffer.lua
+++ b/lua/smark/buffer.lua
@@ -22,28 +22,31 @@ local M = {}
 ---@return LiCursorCoords li_cursor_coords The current cursor coordinates,
 ---specified semantically relative to the list items. An empty table if cursor
 ---is not inside a list block.
----@return boolean to_put_separator_at_start A flat that will be set to true if
+---@return boolean to_put_separator_at_start A flag that will be set to true if
 ---the line preceding the list block is a normal paragraph and an empty
 ---separator line should be added above the list block to separate the two.
+---@return boolean to_put_separator_at_end A similar flag to above, but for the
+---line immediately following the list block.
 function M.get_list_block_around_cursor()
 	local cursor_row, cursor_col = table.unpack(vim.api.nvim_win_get_cursor(0))
 	local cursor_coords = { row = cursor_row, col = cursor_col }
 	local li, li_bounds, li_read_time_lines, read_time_preamble_len = M.scan_text_around_line(cursor_coords.row)
 
 	if li == nil then
-		return nil, {}, {}, {}, false
+		return nil, {}, {}, {}, false, false
 	end
 
 	local li_block_bounds = { upper = li_bounds.upper, lower = li_bounds.lower }
 	local li_block = { li }
 	local read_time_lines = li_read_time_lines
 	local to_put_separator_at_start = false
+	local to_put_separator_at_end = false
 
 	while li_block_bounds.upper > 1 do
 		li, li_bounds, li_read_time_lines = M.scan_text_around_line(li_block_bounds.upper - 1)
 
 		if li == nil then
-			if string.match(li_read_time_lines[#li_read_time_lines], "^%s*$") == nil then
+			if string.len(li_read_time_lines[#li_read_time_lines]) > 0 then
 				to_put_separator_at_start = true
 			end
 			break
@@ -61,6 +64,9 @@ function M.get_list_block_around_cursor()
 		li, li_bounds, li_read_time_lines = M.scan_text_around_line(li_block_bounds.lower + 1)
 
 		if li == nil then
+			if string.len(li_read_time_lines[1]) > 0 then
+				to_put_separator_at_end = true
+			end
 			break
 		end
 
@@ -75,7 +81,12 @@ function M.get_list_block_around_cursor()
 
 	format.fix(li_block, li_cursor_coords, read_time_preamble_len)
 
-	return li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start
+	return li_block_bounds,
+		li_block,
+		read_time_lines,
+		li_cursor_coords,
+		to_put_separator_at_start,
+		to_put_separator_at_end
 end
 
 ---Scan current buffer (0) text around the given line number, and if this text
@@ -100,24 +111,25 @@ end
 function M.scan_text_around_line(line_num)
 	local buf_line_count = vim.api.nvim_buf_line_count(0)
 	local raw_line = vim.api.nvim_buf_get_lines(0, line_num - 1, line_num, true)[1]
-	local li_shell, content_line, preamble_len = M.pattern_match_line(raw_line)
+	local li_shell, content_line, cursor_line_preamble_len = M.pattern_match_line(raw_line)
 
 	local bounds = { upper = line_num, lower = line_num }
 
-	if li_shell == nil and content_line == "" then
-		return nil, bounds, { raw_line }, preamble_len
+	if li_shell == nil and cursor_line_preamble_len == 0 then
+		return nil, bounds, { raw_line }, cursor_line_preamble_len
 	end
 
 	local li = li_shell
 	local content = { content_line }
 	local read_time_lines = { raw_line }
+	local current_line_preamble_len = 0
 
 	if li == nil then
 		for current_lnum = line_num - 1, 1, -1 do
 			raw_line = vim.api.nvim_buf_get_lines(0, current_lnum - 1, current_lnum, true)[1]
-			li_shell, content_line = M.pattern_match_line(raw_line)
+			li_shell, content_line, current_line_preamble_len = M.pattern_match_line(raw_line)
 
-			if content_line == "" then
+			if current_line_preamble_len == 0 then
 				bounds.upper = current_lnum + 1
 				break
 			end
@@ -135,9 +147,9 @@ function M.scan_text_around_line(line_num)
 
 	for current_lnum = line_num + 1, buf_line_count do
 		raw_line = vim.api.nvim_buf_get_lines(0, current_lnum - 1, current_lnum, true)[1]
-		li_shell, content_line = M.pattern_match_line(raw_line)
+		li_shell, content_line, current_line_preamble_len = M.pattern_match_line(raw_line)
 
-		if content_line == "" or li_shell ~= nil then
+		if current_line_preamble_len == 0 or li_shell ~= nil then
 			bounds.lower = current_lnum - 1
 			break
 		end
@@ -151,12 +163,12 @@ function M.scan_text_around_line(line_num)
 	end
 
 	if li == nil then
-		return nil, bounds, read_time_lines, preamble_len
+		return nil, bounds, read_time_lines, cursor_line_preamble_len
 	end
 
 	li.content = content
 
-	return li, bounds, read_time_lines, preamble_len
+	return li, bounds, read_time_lines, cursor_line_preamble_len
 end
 
 ---@param text string Text of line to pattern match
@@ -227,15 +239,15 @@ end
 ---specified by bounds. Also may modify cursor_coords in place (move it down
 ---some rows) if new seaparator lines are written above it.
 ---
----@param li_block ListItem[]
+---@param li_block ListItem[] List block to draw to buffer
 ---@param read_time_lines string[] Array containing original text contents of
 ---list block
----@param li_block_bounds TextBlockBounds
----@param cursor_coords CursorCoords
+---@param li_block_bounds TextBlockBounds Bounds on list block
+---@param cursor_coords CursorCoords Absolute coordinates of cursor
 ---@param to_put_separator_at_start boolean Set to true if an empty line should
 ---be inserted at the beginning to separate the list block from other contents
 ---above.
----@param to_put_separator_at_end boolean Similar to above, but for the end
+---@param to_put_separator_at_end boolean Similar to above, but for the end.
 ---@param new_line_at_cursor boolean Set to true if new line has explicitly
 ---been generated at the cursor
 function M.draw_list_items(

--- a/lua/smark/init.lua
+++ b/lua/smark/init.lua
@@ -70,7 +70,7 @@ function M.setup(opts)
 end
 
 function callback.insert_newline()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 
 	if li_block_bounds == nil then
@@ -88,14 +88,14 @@ function callback.insert_newline()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		new_line_at_cursor
 	)
 	vim.api.nvim_win_set_cursor(0, { cursor_coords.row, cursor_coords.col })
 end
 
 function callback.insert_indent()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 
 	if li_block_bounds == nil then
@@ -113,14 +113,14 @@ function callback.insert_indent()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 	vim.api.nvim_win_set_cursor(0, { cursor_coords.row, cursor_coords.col })
 end
 
 function callback.insert_unindent()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 
 	if li_block_bounds == nil then
@@ -143,14 +143,14 @@ function callback.insert_unindent()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 	vim.api.nvim_win_set_cursor(0, { cursor_coords.row, cursor_coords.col })
 end
 
 function callback.normal_indent()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 
 	if li_block_bounds == nil then
@@ -171,13 +171,13 @@ function callback.normal_indent()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end
 
 function callback.normal_unindent()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 
 	if li_block_bounds == nil then
@@ -198,7 +198,7 @@ function callback.normal_unindent()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end
@@ -226,7 +226,7 @@ function callback.normal_unindent_op()
 end
 
 function callback.normal_o()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 
 	if li_block_bounds == nil then
@@ -243,7 +243,7 @@ function callback.normal_o()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		true
 	)
 	vim.api.nvim_win_set_cursor(0, { cursor_coords.row, cursor_coords.col })
@@ -251,7 +251,7 @@ function callback.normal_o()
 end
 
 function callback.normal_format()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 
 	if li_block_bounds == nil then
@@ -266,13 +266,13 @@ function callback.normal_format()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end
 
 function callback.normal_ordered()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 
 	if li_block_bounds == nil then
@@ -288,13 +288,13 @@ function callback.normal_ordered()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end
 
 function callback.normal_completion()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 
 	if li_block_bounds == nil then
@@ -310,13 +310,13 @@ function callback.normal_completion()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end
 
 function callback.normal_task()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 
 	if li_block_bounds == nil then
@@ -332,7 +332,7 @@ function callback.normal_task()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end

--- a/lua/smark/init.lua
+++ b/lua/smark/init.lua
@@ -10,18 +10,25 @@ function M.setup(opts)
 		--Keymapping settings for list action commands.
 		--Set to false to disable.
 		mappings = {
-			--Format the current list block to be clean / correct
+			--Format the current list block to be clean / correct.
 			format_list = "<leader>lf",
-			--Switch between ordered / unordered list types
+			--Switch between ordered / unordered list types.
 			toggle_ordered = "<leader>lo",
-			--Toggle the completion status of a task list item
+			--Toggle the completion status of a task list item.
 			toggle_completion = "<leader>lx",
-			--Toggle between plain and task list items
+			--Toggle between plain and task list items.
 			toggle_task = "<leader>lt",
 		},
+
+		--Following the starting line of a list item, only contiguous lines that
+		--start with at least one whitespace character can be considered as part of
+		--a multi-line list item.
+		multiline_requires_whitespace = false,
 	}
 
 	opts = vim.tbl_deep_extend("force", default_opts, opts or {})
+
+	buffer.multiline_requires_whitespace = opts.multiline_requires_whitespace
 
 	vim.api.nvim_create_autocmd("FileType", {
 		pattern = { "markdown", "text" },

--- a/lua/smark/operator.lua
+++ b/lua/smark/operator.lua
@@ -5,7 +5,7 @@ local cursor = require("smark.cursor")
 local M = {}
 
 function M.normal_indent()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 	assert(li_block_bounds ~= nil, "op called outside of list block")
 
@@ -23,13 +23,13 @@ function M.normal_indent()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_start,
 		false
 	)
 end
 
 function M.normal_unindent()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 	assert(li_block_bounds ~= nil, "op called outside of list block")
 
@@ -47,13 +47,13 @@ function M.normal_unindent()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end
 
 function M.visual_indent()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 	assert(li_block_bounds ~= nil, "op called outside of list block")
 
@@ -73,13 +73,13 @@ function M.visual_indent()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end
 
 function M.visual_unindent()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 	assert(li_block_bounds ~= nil, "op called outside of list block")
 
@@ -99,13 +99,13 @@ function M.visual_unindent()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end
 
 function M.visual_toggle_ordered()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 	assert(li_block_bounds ~= nil, "op called outside of list block")
 
@@ -123,13 +123,13 @@ function M.visual_toggle_ordered()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end
 
 function M.visual_toggle_completion()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 	assert(li_block_bounds ~= nil, "op called outside of list block")
 
@@ -147,13 +147,13 @@ function M.visual_toggle_completion()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end
 
 function M.visual_toggle_task()
-	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start =
+	local li_block_bounds, li_block, read_time_lines, li_cursor_coords, to_put_separator_at_start, to_put_separator_at_end =
 		buffer.get_list_block_around_cursor()
 	assert(li_block_bounds ~= nil, "op called outside of list block")
 
@@ -171,7 +171,7 @@ function M.visual_toggle_task()
 		li_block_bounds,
 		cursor_coords,
 		to_put_separator_at_start,
-		false,
+		to_put_separator_at_end,
 		false
 	)
 end

--- a/tests/test_newline.lua
+++ b/tests/test_newline.lua
@@ -344,6 +344,9 @@ T["insert_CR"]["can automatically insert separating lines and new list item simu
 end
 
 T["insert_CR"]["inserts new separating line between prose line directly below"] = function()
+	--Set multiline_requires_whitespace option
+	child.lua([[require('smark').setup({multiline_requires_whitespace = true})]])
+
 	child.api.nvim_buf_set_lines(0, 0, -2, true, {
 		"- There should be a separating line below",
 		"This should be considered a prose line.",

--- a/tests/test_newline.lua
+++ b/tests/test_newline.lua
@@ -324,7 +324,7 @@ T["insert_CR"]["can automatically insert separating lines and new list item simu
 	child.api.nvim_buf_set_lines(0, 0, -2, true, {
 		"This should be a normal paragraph here.",
 		"- There should be a separating line above",
-		"This should become part of the list content",
+		" This should become part of the list content",
 		"- A new list item should be made below",
 	})
 	child.api.nvim_win_set_cursor(0, { 4, 0 })
@@ -338,6 +338,25 @@ T["insert_CR"]["can automatically insert separating lines and new list item simu
 		"  This should become part of the list content",
 		"- A new list item should be made below",
 		"- Foobar",
+	}
+
+	eq(result_buffer, expected_buffer)
+end
+
+T["insert_CR"]["inserts new separating line between prose line directly below"] = function()
+	child.api.nvim_buf_set_lines(0, 0, -2, true, {
+		"- There should be a separating line below",
+		"This should be considered a prose line.",
+	})
+	child.api.nvim_win_set_cursor(0, { 1, 0 })
+	child.type_keys("A<CR>Foobar")
+
+	local result_buffer = child.api.nvim_buf_get_lines(0, 0, -2, true)
+	local expected_buffer = {
+		"- There should be a separating line below",
+		"- Foobar",
+		"",
+		"This should be considered a prose line.",
 	}
 
 	eq(result_buffer, expected_buffer)


### PR DESCRIPTION
- Currently, any non-empty line following a line that is a valid list item is considered a continuation of the list item (multiline list)
- However, I began to find this personally annoying since these subsequent lines are often meant to be the start of a prose paragraph and smark automatically reformats them to be part of the preceding list
- I now expose an option that requires these prose lines to start with at least one whitespace character (i.e. some indentation) to be considered as a continuation of the list item above